### PR TITLE
Copy dmd-transitional patches from 2.070.2.s11

### DIFF
--- a/dlang.Dockerfile
+++ b/dlang.Dockerfile
@@ -4,7 +4,7 @@ ENV \
     # Environment variables for program versions
     # (scripts use them to know which version to install)
     VERSION_EBTREE=v6.0.socio6 \
-    VERSION_DMD1=v1.078.0 \
+    VERSION_DMD1=v1.080.0 \
     VERSION_TANGORT=v1.6.0 \
     VERSION_DMD=2.070.2-0 \
     VERSION_DMD_TRANSITIONAL=v2.070.2 \

--- a/docker/dlang/dmd-transitional-patches/dmd/0001-Use-sc-transitional.ini-dmd-transitional.conf.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0001-Use-sc-transitional.ini-dmd-transitional.conf.patch
@@ -1,7 +1,7 @@
-From 6437bf29e14a3c758d2236d6abdf5125b2250b73 Mon Sep 17 00:00:00 2001
+From 0c6d41aa940026cbe15a736f69a80805114079bc Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Tue, 9 Feb 2016 20:37:37 +0200
-Subject: [PATCH 1/3] Use sc-transitional.ini/dmd-transitional.conf
+Subject: [PATCH 01/21] Use sc-transitional.ini/dmd-transitional.conf
 
 Looks for dmd configuration under different name from upstream compiler
 ---
@@ -26,6 +26,6 @@ index 22e1bcbf7..d5d728154 100644
          }
          else
          {
---
-2.11.1
+-- 
+2.12.2
 

--- a/docker/dlang/dmd-transitional-patches/dmd/0002-Fix-test-suite-C-test-with-GCC-5.1-dual-ABI.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0002-Fix-test-suite-C-test-with-GCC-5.1-dual-ABI.patch
@@ -1,7 +1,7 @@
-From 4bfbd40d2ab605b79ac977116f769261dd8790f4 Mon Sep 17 00:00:00 2001
+From 89d7f628e12951a17fbea77e2411690d5aac12a7 Mon Sep 17 00:00:00 2001
 From: Vladimir Panteleev <git@thecybershadow.net>
 Date: Tue, 19 Apr 2016 06:01:02 +0000
-Subject: [PATCH 2/3] Fix test suite C++ test with GCC 5.1 dual ABI
+Subject: [PATCH 02/21] Fix test suite C++ test with GCC 5.1 dual ABI
 
 GCC 5.1 introduced new implementations of std::string and std::list:
 
@@ -20,18 +20,6 @@ cppa.d:(.text._D4cppa6test14FZv+0x3a): undefined reference to `foo14f(std::char_
 cppa.o: In function `_D4cppa7testeh3FZv':
 cppa.d:(.text._D4cppa7testeh3FZv+0x19): undefined reference to `throwle()'
 collect2: error: ld returned 1 exit status
---- errorlevel 1
-
-When the .cpp file is compiled with g++ 5.3.0, the actual function
-signatures in the cppb.o object file are:
-
-foo14a(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)
-foo14b(std::__cxx11::basic_string<int, std::char_traits<int>, std::allocator<int> >*)
-foo14f(std::char_traits<char>*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)
-
-Fortunately, it is easily possible to disable the new feature
-by defining _GLIBCXX_USE_CXX11_ABI as 0 before including any standard
-headers.
 ---
  test/runnable/extra-files/cppb.cpp | 32 ++++++++++++++++++++++++++++++++
  1 file changed, 32 insertions(+)
@@ -77,5 +65,5 @@ index 758ed4f94..2b3bf66b6 100644
  #include <stdio.h>
  #include <assert.h>
 -- 
-2.11.1
+2.12.2
 

--- a/docker/dlang/dmd-transitional-patches/dmd/0003-Fix-grep-dependency-on-locale-for-DDoc-tests.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0003-Fix-grep-dependency-on-locale-for-DDoc-tests.patch
@@ -1,7 +1,7 @@
-From c0683250de3246634c04c2bb412e751e8b89a297 Mon Sep 17 00:00:00 2001
+From d4988c9b60fa7ae785c5d7d9d35a0c8e216b4eba Mon Sep 17 00:00:00 2001
 From: Vladimir Panteleev <git@thecybershadow.net>
 Date: Tue, 19 Apr 2016 02:28:07 +0000
-Subject: [PATCH 3/3] Fix grep dependency on locale for DDoc tests
+Subject: [PATCH 03/21] Fix grep dependency on locale for DDoc tests
 
 By default, grep attempts to detect whether an input file is binary,
 and if so, in the case of a match it simply prints "Binary file foo
@@ -34,5 +34,5 @@ index 79dcf7af4..01c901bb3 100755
  if [ $? -ne 0 ]; then
      exit 1;
 -- 
-2.11.1
+2.12.2
 

--- a/docker/dlang/dmd-transitional-patches/dmd/0004-fix-heisenbug-in-evalu8.c.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0004-fix-heisenbug-in-evalu8.c.patch
@@ -1,0 +1,25 @@
+From 59f4bb3aeb6804e2d83a069f09e4b6740fd6b838 Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Thu, 7 Jan 2016 13:38:03 -0800
+Subject: [PATCH 04/21] fix heisenbug in evalu8.c
+
+---
+ src/backend/evalu8.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/backend/evalu8.c b/src/backend/evalu8.c
+index 3f3625707..088455fc8 100644
+--- a/src/backend/evalu8.c
++++ b/src/backend/evalu8.c
+@@ -546,7 +546,7 @@ elem *poptelem(elem *e)
+                 if (e2->Eoper == OPconst)
+                 {   targ_int i = e2->EV.Vint;
+ 
+-                    if (i && e1->EV.sp.Vsym->Sfl == FLgot)
++                    if (i && e1->Eoper == OPrelconst && e1->EV.sp.Vsym->Sfl == FLgot)
+                         break;
+                     if (e->Eoper == OPmin)
+                         i = -i;
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0005-Replace-UTF-8-invalid-embedded-characters-with-valid.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0005-Replace-UTF-8-invalid-embedded-characters-with-valid.patch
@@ -1,0 +1,32 @@
+From 5932c3981ff383309194f4bbd13297e6450e41db Mon Sep 17 00:00:00 2001
+From: calexHG <calexHG@users.noreply.github.com>
+Date: Tue, 8 Mar 2016 18:30:45 -0500
+Subject: [PATCH 05/21] =?UTF-8?q?Replace=20UTF-8=E2=80=93invalid=20embedde?=
+ =?UTF-8?q?d=20characters=20with=20valid=20UTF-8?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The copyright symbol, when encoded in Win-1252, is not valid UTF-8. D assumes UTF-8 and chokes on it, so this commit replaces it with the valid, multibyte UTF-8 encoding of the symbol.
+
+Note: I feel it would be safer to simply use "(C)", as is used everywhere else in the code, but that would seem to ignore the intentions of the original author.
+---
+ src/backend/cdef.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/backend/cdef.h b/src/backend/cdef.h
+index 53ebbcc90..83da998dd 100644
+--- a/src/backend/cdef.h
++++ b/src/backend/cdef.h
+@@ -574,7 +574,7 @@ typedef int bool;
+ #endif
+ 
+ #if _WINDLL
+-#define COPYRIGHT "Copyright © 2001 Digital Mars"
++#define COPYRIGHT "Copyright Â© 2001 Digital Mars"
+ #else
+ #ifdef DEBUG
+ #define COPYRIGHT "Copyright (C) Digital Mars 2000-2013.  All Rights Reserved.\n\
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0006-fix-Issue-15779-DWARF-EH-fails-when-using-stack-stom.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0006-fix-Issue-15779-DWARF-EH-fails-when-using-stack-stom.patch
@@ -1,0 +1,67 @@
+From ac6938ff254847d3bd4f2f9a15e3808a83246dde Mon Sep 17 00:00:00 2001
+From: Martin Nowak <code@dawg.eu>
+Date: Fri, 25 Mar 2016 21:39:38 +0100
+Subject: [PATCH 06/21] fix Issue 15779 - DWARF EH fails when using stack
+ stomping (-gx)
+
+---
+ src/backend/cod3.c        |  9 ++++++---
+ test/runnable/test15779.d | 22 ++++++++++++++++++++++
+ 2 files changed, 28 insertions(+), 3 deletions(-)
+ create mode 100644 test/runnable/test15779.d
+
+diff --git a/src/backend/cod3.c b/src/backend/cod3.c
+index 1e5fe7925..57e409da9 100644
+--- a/src/backend/cod3.c
++++ b/src/backend/cod3.c
+@@ -3911,13 +3911,16 @@ void epilog(block *b)
+                     reg_t reg = CX;
+                     mfuncreg &= ~mask[reg];
+                     unsigned grex = I64 ? REX_W << 16 : 0;
+-                    c = genc2(c,0xC7,grex | modregrmx(3,0,reg),value);  // MOV reg,value
+-                    code *c1 = gen2sib(CNIL,0x89,grex | modregrm(0,reg,4),modregrm(0,4,SP));  // MOV [ESP],reg
++                    code *c1 = genc2(CNIL,0xC7,grex | modregrmx(3,0,reg),value);// MOV reg,value
++                    gen2sib(c1,0x89,grex | modregrm(0,reg,4),modregrm(0,4,SP)); // MOV [ESP],reg
+                     genc2(c1,0x81,grex | modregrm(3,0,SP),REGSIZE);     // ADD ESP,REGSIZE
+                     genregs(c1,0x39,SP,BP);                             // CMP EBP,ESP
+                     if (I64)
+                         code_orrex(c1,REX_W);
+-                    genjmp(c1,JNE,FLcode,(block *)c1);                  // JNE L1
++                    code *cjmp = genjmp(CNIL,JNE,FLcode,(block *)c1);           // JNE L1
++                    // explicitly mark as short jump, needed for correct retsize calculation (Bugzilla 15779)
++                    cjmp->Iflags &= ~CFjmp16;
++                    c1 = cat(c1, cjmp);
+                     gen1(c1,0x58 + BP);                                 // POP BP
+                     c = cat(c,c1);
+                 }
+diff --git a/test/runnable/test15779.d b/test/runnable/test15779.d
+new file mode 100644
+index 000000000..557054a04
+--- /dev/null
++++ b/test/runnable/test15779.d
+@@ -0,0 +1,22 @@
++// REQUIRED_ARGS: -gx
++
++// 15779
++
++import core.thread;
++
++int main()
++{
++    try
++    {
++        bar();
++    }
++    catch (Exception e)
++    {
++    }
++    return 0;
++}
++
++void bar()
++{
++    new Fiber({ throw new Exception("fly"); }).call();
++}
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0007-fix-Issue-15898-REG2.069-Internal-error-backend-cgco.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0007-fix-Issue-15898-REG2.069-Internal-error-backend-cgco.patch
@@ -1,0 +1,67 @@
+From 73098158681fcc6ada7476efb6c439fa7c04f2fa Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Wed, 13 Apr 2016 00:56:58 -0700
+Subject: [PATCH 07/21] fix Issue 15898 - [REG2.069] Internal error:
+ backend\cgcod.c 1651
+
+---
+ src/backend/cod4.c          |  4 ++--
+ test/compilable/test15898.d | 27 +++++++++++++++++++++++++++
+ 2 files changed, 29 insertions(+), 2 deletions(-)
+ create mode 100644 test/compilable/test15898.d
+
+diff --git a/src/backend/cod4.c b/src/backend/cod4.c
+index fb525bc1a..b373abf6f 100644
+--- a/src/backend/cod4.c
++++ b/src/backend/cod4.c
+@@ -3779,12 +3779,12 @@ code *cdpair(elem *e, regm_t *pretregs)
+     retregs = *pretregs & allregs;
+     if  (!retregs)
+         retregs = allregs;
+-    regs1 = retregs & (mLSW | mBP);
++    regs1 = retregs & mLSW;
+     regs2 = retregs & mMSW;
+     if (e->Eoper == OPrpair)
+     {
+         regs1 = regs2;
+-        regs2 = retregs & (mLSW | mBP);
++        regs2 = retregs & mLSW;
+     }
+     //printf("1: regs1 = %s, regs2 = %s\n", regm_str(regs1), regm_str(regs2));
+     c1 = codelem(e->E1, &regs1, FALSE);
+diff --git a/test/compilable/test15898.d b/test/compilable/test15898.d
+new file mode 100644
+index 000000000..01c325e99
+--- /dev/null
++++ b/test/compilable/test15898.d
+@@ -0,0 +1,27 @@
++// REQUIRED_ARGS: -O
++// https://issues.dlang.org/show_bug.cgi?id=15898
++
++int addAssignSimple(int[] , const(int)[] )
++{
++    uint c;
++    return c;
++}
++
++void mulKaratsuba(int[] result, const(int)[] x, const(int)[] y, int[] )
++{
++    const(int)[] y1 = y;
++    int[] newscratchbuff;
++    int[] resultHigh = result;
++
++    bool ysmaller2 = x.length >= y1.length;
++    newscratchbuff[0..y1.length] = resultHigh;
++    mulKaratsuba(
++        resultHigh[1..$],
++        ysmaller2 ? x[1..$] : y1,
++        ysmaller2 ? y1 : x,
++        newscratchbuff[y1.length..$]
++    );
++
++    addAssignSimple(resultHigh[1..$], newscratchbuff[0..y1.length]);
++}
++
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0008-fix-Issue-15629-REG2.066.0-wrong-code-with-O-inline-.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0008-fix-Issue-15629-REG2.066.0-wrong-code-with-O-inline-.patch
@@ -1,0 +1,63 @@
+From 4680a4f63c470fb532f48425e244ab8bec54e57d Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Thu, 14 Apr 2016 22:41:32 -0700
+Subject: [PATCH 08/21] fix Issue 15629 - [REG2.066.0] wrong code with '-O
+ -inline' but correct with '-O'
+
+---
+ src/backend/cod2.c    |  2 +-
+ test/runnable/mars1.d | 18 ++++++++++++++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/src/backend/cod2.c b/src/backend/cod2.c
+index dead1006c..a57a42d8f 100644
+--- a/src/backend/cod2.c
++++ b/src/backend/cod2.c
+@@ -4565,7 +4565,7 @@ code *cdabs( elem *e, regm_t *pretregs)
+         if (!I16 && sz == REGSIZE)
+         {   regm_t scratch = allregs & ~retregs;
+             reg = findreg(retregs);
+-            cg = allocreg(&scratch,&r,TYint);
++            cg = cat(cg, allocreg(&scratch,&r,TYint));
+             cg = cat(cg,getregs(retregs));
+             cg = genmovreg(cg,r,reg);                                   // MOV r,reg
+             cg = genc2(cg,0xC1,modregrmx(3,7,r),REGSIZE * 8 - 1);       // SAR r,31/63
+diff --git a/test/runnable/mars1.d b/test/runnable/mars1.d
+index cd11bb3d4..0d85662b9 100644
+--- a/test/runnable/mars1.d
++++ b/test/runnable/mars1.d
+@@ -1424,6 +1424,23 @@ void test15272()
+ 
+ ////////////////////////////////////////////////////////////////////////
+ 
++// https://issues.dlang.org/show_bug.cgi?id=15629 comment 3
++// -O
++
++void test15629()
++{
++    int[] a = [3];
++    int value = a[0] >= 0 ? a[0] : -a[0];
++    assert(a[0] == 3);
++    writeln(value, a);
++}
++
++void writeln(int v, int[] a)
++{
++}
++
++////////////////////////////////////////////////////////////////////////
++
+ int main()
+ {
+     testgoto();
+@@ -1473,6 +1490,7 @@ int main()
+     test14987();
+     test15272();
+ 
++    test15629();
+     printf("Success\n");
+     return 0;
+ }
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0009-fix-Issue-16225-REG-2.068-Internal-error-cod1.c-1338.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0009-fix-Issue-16225-REG-2.068-Internal-error-cod1.c-1338.patch
@@ -1,0 +1,49 @@
+From a5f031b8b5afe2c2ec70f923df4a5416a5a0e035 Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Fri, 8 Jul 2016 23:23:49 -0700
+Subject: [PATCH 09/21] fix Issue 16225 - [REG 2.068] Internal error cod1.c
+ 1338 with -O
+
+---
+ src/backend/cod1.c          |  3 ++-
+ test/compilable/test16225.d | 14 ++++++++++++++
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+ create mode 100644 test/compilable/test16225.d
+
+diff --git a/src/backend/cod1.c b/src/backend/cod1.c
+index 733052a2a..26b206dff 100644
+--- a/src/backend/cod1.c
++++ b/src/backend/cod1.c
+@@ -1375,7 +1375,8 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
+         if (sz == 1)
+         {   /* Don't use SI or DI for this variable     */
+             s->Sflags |= GTbyte;
+-            if (e->EV.sp.Voffset > 1)
++            if (e->EV.sp.Voffset > 1 ||
++                I64)                            // could work if restrict reg to AH,BH,CH,DH
+                 s->Sflags &= ~GTregcand;
+         }
+         else if (e->EV.sp.Voffset)
+diff --git a/test/compilable/test16225.d b/test/compilable/test16225.d
+new file mode 100644
+index 000000000..6600842b7
+--- /dev/null
++++ b/test/compilable/test16225.d
+@@ -0,0 +1,14 @@
++// REQUIRED_ARGS: -O -m64
++// PERMUTE_ARGS:
++
++// https://issues.dlang.org/show_bug.cgi?id=16225
++
++struct C
++{
++    hash_t foo( )
++    {
++        int y;
++        return ((cast(ubyte*)&y)[1]);
++    }
++}
++
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0010-Fix-Issue-15573-O-inline-causes-wrong-code-with-idiv.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0010-Fix-Issue-15573-O-inline-causes-wrong-code-with-idiv.patch
@@ -1,0 +1,38 @@
+From 56649327c580b6f664c9465caf4993f96fa95f77 Mon Sep 17 00:00:00 2001
+From: Daniel Murphy <yebblies@gmail.com>
+Date: Sun, 20 Mar 2016 18:42:09 +1100
+Subject: [PATCH 10/21] Fix Issue 15573 - -O -inline causes wrong code with
+ idiv instruction
+
+---
+ src/backend/cod2.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+ mode change 100644 => 100755 src/backend/cod2.c
+
+diff --git a/src/backend/cod2.c b/src/backend/cod2.c
+old mode 100644
+new mode 100755
+index a57a42d8f..142a85a61
+--- a/src/backend/cod2.c
++++ b/src/backend/cod2.c
+@@ -1664,6 +1664,8 @@ code *cdnot(elem *e,regm_t *pretregs)
+                 cs.IFL2 = FLconst;
+                 cs.IEV2.Vint = 0;
+             }
++            if (I64 && (sz == 1) && reg >= 4)
++                cs.Irex |= REX;
+             cs.Iop ^= (sz == 1);
+             code_newreg(&cs,reg);
+             c = gen(c,&cs);                             // CMP e1,0
+@@ -1698,6 +1700,8 @@ code *cdnot(elem *e,regm_t *pretregs)
+             cs.IFL2 = FLconst;
+             cs.IEV2.Vint = 1;
+         }
++        if (I64 && (sz == 1) && reg >= 4)
++            cs.Irex |= REX;
+         cs.Iop ^= (sz == 1);
+         code_newreg(&cs,reg);
+         c = gen(c,&cs);                         // CMP e1,1
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0011-fix-Issue-10225-core.simd-wrong-codegen-for-XMM.STOU.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0011-fix-Issue-10225-core.simd-wrong-codegen-for-XMM.STOU.patch
@@ -1,0 +1,80 @@
+From 158c9e87fc06cf86a4be4e4e614730a9faa0388e Mon Sep 17 00:00:00 2001
+From: Martin Nowak <code@dawg.eu>
+Date: Sun, 3 Apr 2016 15:58:32 +0200
+Subject: [PATCH 11/21] fix Issue 10225 - core.simd wrong codegen for
+ XMM.STOUPS with __simd_sto
+
+- add missing STO* ops to codegen
+---
+ src/backend/cgxmm.c     | 10 ++++++++--
+ test/runnable/testxmm.d | 22 +++++++++++++++++-----
+ 2 files changed, 25 insertions(+), 7 deletions(-)
+
+diff --git a/src/backend/cgxmm.c b/src/backend/cgxmm.c
+index dd4e1f0cf..bde56682d 100644
+--- a/src/backend/cgxmm.c
++++ b/src/backend/cgxmm.c
+@@ -37,8 +37,14 @@ unsigned xmmoperator(tym_t tym, unsigned oper);
+ 
+ bool isXMMstore(unsigned op)
+ {
+-    // Not very efficient
+-    return op == STOSS || op == STOSD || op == STOAPS || op == STOAPD || op == STODQA || op == STOQ;
++    switch (op)
++    {
++    case STOSS: case STOAPS: case STOUPS:
++    case STOSD: case STOAPD: case STOUPD:
++    case STOD: case STOQ: case STODQA: case STODQU:
++    case STOHPD: case STOHPS: case STOLPD: case STOLPS: return true;
++    default: return false;
++    }
+ }
+ 
+ /*******************************************
+diff --git a/test/runnable/testxmm.d b/test/runnable/testxmm.d
+index f3483cc6b..1d73e24a9 100644
+--- a/test/runnable/testxmm.d
++++ b/test/runnable/testxmm.d
+@@ -1032,22 +1032,34 @@ float4 test5(float4 a, float4 b)
+ 
+     a = __simd_sto(XMM.STOSS, a, b);
+     a = __simd_sto(XMM.STOSD, a, b);
++    a = __simd_sto(XMM.STOD, a, b);
++    a = __simd_sto(XMM.STOQ, a, b);
+     a = __simd_sto(XMM.STOAPS, a, b);
+     a = __simd_sto(XMM.STOAPD, a, b);
+     a = __simd_sto(XMM.STODQA, a, b);
+-    //a = __simd_sto(XMM.STOD, a, b);
+-    a = __simd_sto(XMM.STOQ, a, b);
++    a = __simd_sto(XMM.STOUPS, a, b);
++    a = __simd_sto(XMM.STOUPD, a, b);
++    a = __simd_sto(XMM.STODQU, a, b);
++    a = __simd_sto(XMM.STOHPD, a, b);
++    a = __simd_sto(XMM.STOHPS, a, b);
++    a = __simd_sto(XMM.STOLPD, a, b);
++    a = __simd_sto(XMM.STOLPS, a, b);
+ 
+     a = __simd(XMM.LODSS, a);
+     a = __simd(XMM.LODSD, a);
+     a = __simd(XMM.LODAPS, a);
+     a = __simd(XMM.LODAPD, a);
+     a = __simd(XMM.LODDQA, a);
+-    //a = __simd(XMM.LODD, a);
++    a = __simd(XMM.LODUPS, a);
++    a = __simd(XMM.LODUPD, a);
++    a = __simd(XMM.LODDQU, a);
++    a = __simd(XMM.LODD, a);
+     a = __simd(XMM.LODQ, a);
++    a = __simd(XMM.LODHPD, a);
++    a = __simd(XMM.LODHPS, a);
++    a = __simd(XMM.LODLPD, a);
++    a = __simd(XMM.LODLPS, a);
+ 
+-    a = __simd(XMM.LODDQU, a);
+-    a = __simd_sto(XMM.STODQU, a, b);
+     //MOVDQ2Q  = 0xF20FD6,        // MOVDQ2Q mmx, xmm          F2 0F D6 /r
+ /+
+     LODHPD   = 0x660F16,        // MOVHPD xmm, mem64         66 0F 16 /r
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0012-fix-Issue-15861-REG-2.069-Wrong-double-to-string-con.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0012-fix-Issue-15861-REG-2.069-Wrong-double-to-string-con.patch
@@ -1,0 +1,50 @@
+From 38a1535d678d3117980cf98af54c3404919a712b Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Mon, 11 Apr 2016 02:06:48 -0700
+Subject: [PATCH 12/21] fix Issue 15861 - [REG 2.069] Wrong double-to-string
+ conversion with -O
+
+---
+ src/backend/cgelem.c      |  5 ++---
+ test/runnable/test15861.d | 10 ++++++++++
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+ create mode 100644 test/runnable/test15861.d
+
+diff --git a/src/backend/cgelem.c b/src/backend/cgelem.c
+index dd50c6a6f..e4a7340ac 100644
+--- a/src/backend/cgelem.c
++++ b/src/backend/cgelem.c
+@@ -3577,12 +3577,11 @@ STATIC elem * eleq(elem *e, goal_t goal)
+         if (tysize(e1->Ety) == 2 * REGSIZE &&
+             e1->Eoper == OPvar &&
+             e2->Eoper == OPvar &&
+-            goal == GOALnone
++            goal == GOALnone &&
++            !tyfloating(e1->Ety)
+            )
+         {
+             tym_t ty = (REGSIZE == 8) ? TYllong : TYint;
+-            if (tyfloating(e1->Ety) && REGSIZE >= 4)
+-                ty = (REGSIZE == 8) ? TYdouble : TYfloat;
+             ty |= e1->Ety & ~mTYbasic;
+             e2->Ety = ty;
+             e->Ety = ty;
+diff --git a/test/runnable/test15861.d b/test/runnable/test15861.d
+new file mode 100644
+index 000000000..93b94c4c1
+--- /dev/null
++++ b/test/runnable/test15861.d
+@@ -0,0 +1,10 @@
++// REQUIRED_ARGS: -O
++// https://issues.dlang.org/show_bug.cgi?id=15861
++
++import std.format;
++
++void main()
++{
++    assert(format("%.18g", 4286853117.0) == "4286853117");
++}
++
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0013-fix-Issue-13674-ICE-el.c-with-simd-multiplication-of.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0013-fix-Issue-13674-ICE-el.c-with-simd-multiplication-of.patch
@@ -1,0 +1,48 @@
+From 43ccfec449abfb9e226843b283bf27a56e5ac80e Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Wed, 20 Apr 2016 01:58:06 -0700
+Subject: [PATCH 13/21] fix Issue 13674 - ICE(el.c) with simd multiplication of
+ short8
+
+---
+ src/backend/cgelem.c    | 2 +-
+ test/runnable/testxmm.d | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/backend/cgelem.c b/src/backend/cgelem.c
+index e4a7340ac..9eb38fbd4 100644
+--- a/src/backend/cgelem.c
++++ b/src/backend/cgelem.c
+@@ -1004,7 +1004,7 @@ STATIC elem * elmul(elem *e, goal_t goal)
+             }
+         }
+ 
+-        if (tyintegral(tym))
++        if (tyintegral(tym) && !tyvector(tym))
+         {   int i;
+ 
+             i = ispow2(el_tolong(e2));          /* check for power of 2 */
+diff --git a/test/runnable/testxmm.d b/test/runnable/testxmm.d
+index 1d73e24a9..7764a8104 100644
+--- a/test/runnable/testxmm.d
++++ b/test/runnable/testxmm.d
+@@ -239,6 +239,7 @@ void test2c()
+     static assert(!__traits(compiles, v1 <<= 1));
+     static assert(!__traits(compiles, v1 >>= 1));
+     static assert(!__traits(compiles, v1 >>>= 1));
++    v1 = v1 * 3;
+ 
+     //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+     static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+@@ -1398,7 +1399,7 @@ void foo13988(double[] arr)
+ {
+     static ulong repr(double d) { return *cast(ulong*)&d; }
+     foreach (x; arr)
+-	assert(repr(arr[0]) == *cast(ulong*)&(arr[0]));
++        assert(repr(arr[0]) == *cast(ulong*)&(arr[0]));
+ }
+ 
+ 
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0014-fix-Issue-11585-ICE-cgcod.c-with-SIMD-and-O.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0014-fix-Issue-11585-ICE-cgcod.c-with-SIMD-and-O.patch
@@ -1,0 +1,71 @@
+From a94f59965d2450b74866df03d8d06acb4b0b6040 Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Mon, 25 Apr 2016 01:02:49 -0700
+Subject: [PATCH 14/21] fix Issue 11585 - ICE(cgcod.c) with SIMD and -O
+
+---
+ src/backend/cgcod.c     |  4 ++--
+ src/backend/cod1.c      |  2 ++
+ test/runnable/testxmm.d | 11 +++++++++++
+ 3 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/backend/cgcod.c b/src/backend/cgcod.c
+index 69ecb4cfc..667437960 100644
+--- a/src/backend/cgcod.c
++++ b/src/backend/cgcod.c
+@@ -2151,7 +2151,7 @@ bool cssave(elem *e,regm_t regm,unsigned opsflag)
+             return false;
+ 
+         //printf("cssave(e = %p, regm = %s, opsflag = x%x)\n", e, regm_str(regm), opsflag);
+-        regm &= mBP | ALLREGS | mES;    /* just to be sure              */
++        regm &= mBP | ALLREGS | mES | XMMREGS;    /* just to be sure              */
+ 
+ #if 0
+         /* Do not register CSEs if they are register variables and      */
+@@ -2575,7 +2575,7 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
+         if (e->Ecount)                          /* if common subexp     */
+         {
+             /* if no return value       */
+-            if ((*pretregs & (mSTACK | mES | ALLREGS | mBP)) == 0)
++            if ((*pretregs & (mSTACK | mES | ALLREGS | mBP | XMMREGS)) == 0)
+             {   if (tysize(e->Ety) == 1)
+                     *pretregs |= BYTEREGS;
+                 else if (tybasic(e->Ety) == TYdouble || tybasic(e->Ety) == TYdouble_alias)
+diff --git a/src/backend/cod1.c b/src/backend/cod1.c
+index 26b206dff..d96ac6aad 100644
+--- a/src/backend/cod1.c
++++ b/src/backend/cod1.c
+@@ -572,6 +572,8 @@ code *loadea(elem *e,code *cs,unsigned op,unsigned reg,targ_size_t offset,
+   {
+         assert(!EOP(e));                /* can't handle this            */
+         regm_t rm = regcon.cse.mval & ~regcon.cse.mops & ~regcon.mvar; // possible regs
++        if (op == 0xFF && reg == 6)
++            rm &= ~XMMREGS;             // can't PUSH an XMM register
+         if (sz > REGSIZE)               // value is in 2 or 4 registers
+         {
+                 if (I16 && sz == 8)     // value is in 4 registers
+diff --git a/test/runnable/testxmm.d b/test/runnable/testxmm.d
+index 7764a8104..a873e5d53 100644
+--- a/test/runnable/testxmm.d
++++ b/test/runnable/testxmm.d
+@@ -1424,6 +1424,17 @@ void test15123()
+ }
+ 
+ /*****************************************/
++// https://issues.dlang.org/show_bug.cgi?id=11585
++
++ubyte16 test11585(ubyte16* d)
++{
++    ubyte16 a;
++    if (d is null) return a;
++
++    return __simd(XMM.PCMPEQB, *d, *d);
++}
++
++/*****************************************/
+ 
+ int main()
+ {
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0015-fix-Issue-16080-REG2.071.0-Internal-error-backend-cg.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0015-fix-Issue-16080-REG2.071.0-Internal-error-backend-cg.patch
@@ -1,0 +1,96 @@
+From 1a0e7c5e15fcf5ad07943ec94d9a80a9da41fdfd Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Tue, 31 May 2016 23:15:18 -0700
+Subject: [PATCH 15/21] fix Issue 16080 - [REG2.071.0] Internal error:
+ backend\cgobj.c 3406 when building static library
+
+---
+ src/backend/cgobj.c                      | 10 +++++++---
+ test/compilable/extra-files/test16080b.d |  6 ++++++
+ test/compilable/imports/imp16080.d       |  4 ++++
+ test/compilable/test16080.d              |  6 ++++++
+ 4 files changed, 23 insertions(+), 3 deletions(-)
+ create mode 100644 test/compilable/extra-files/test16080b.d
+ create mode 100644 test/compilable/imports/imp16080.d
+ create mode 100644 test/compilable/test16080.d
+
+diff --git a/src/backend/cgobj.c b/src/backend/cgobj.c
+index 29907dcd0..a2353e40a 100644
+--- a/src/backend/cgobj.c
++++ b/src/backend/cgobj.c
+@@ -2490,7 +2490,7 @@ int Obj::external_def(const char *name)
+ {   unsigned len;
+     char *e;
+ 
+-    //dbg_printf("Obj::external_def('%s')\n",name);
++    //printf("Obj::external_def('%s', %d)\n",name,obj.extidx + 1);
+     assert(name);
+     len = strlen(name);                 // length of identifier
+     if (obj.extdatai + len + ONS_OHD + 1 > sizeof(obj.extdata))
+@@ -2514,7 +2514,7 @@ int Obj::external_def(const char *name)
+ 
+ int Obj::external(Symbol *s)
+ {
+-    //dbg_printf("Obj::external('%s')\n",s->Sident);
++    //printf("Obj::external('%s', %d)\n",s->Sident, obj.extidx + 1);
+     symbol_debug(s);
+     if (obj.extdatai + (IDMAX + IDOHD) + 3 > sizeof(obj.extdata))
+         outextdata();
+@@ -2580,7 +2580,8 @@ int Obj::common_block(Symbol *s,int flag,targ_size_t size,targ_size_t count)
+   unsigned long length;
+   unsigned ti;
+ 
+-    //dbg_printf("Obj::common_block('%s',%d,%d,%d)\n",s->Sident,flag,size,count);
++    //printf("Obj::common_block('%s',%d,%d,%d, %d)\n",s->Sident,flag,size,count, obj.extidx + 1);
++    obj.reset_symbuf->write(&s, sizeof(s));
+     outextdata();               // borrow the extdata[] storage
+     i = Obj::mangle(s,obj.extdata);
+ 
+@@ -3413,7 +3414,10 @@ int Obj::reftoident(int seg,targ_size_t offset,Symbol *s,targ_size_t val,
+             {   external = s->Sxtrnnum;
+ #ifdef DEBUG
+                 if (external > obj.extidx)
++                {
++                    printf("obj.extidx = %d\n", obj.extidx);
+                     symbol_print(s);
++                }
+ #endif
+                 assert(external <= obj.extidx);
+             }
+diff --git a/test/compilable/extra-files/test16080b.d b/test/compilable/extra-files/test16080b.d
+new file mode 100644
+index 000000000..9cd9fc8d5
+--- /dev/null
++++ b/test/compilable/extra-files/test16080b.d
+@@ -0,0 +1,6 @@
++import imp16080;
++
++void test2() {
++	A!() v = A!().a;
++}
++
+diff --git a/test/compilable/imports/imp16080.d b/test/compilable/imports/imp16080.d
+new file mode 100644
+index 000000000..1afd9b565
+--- /dev/null
++++ b/test/compilable/imports/imp16080.d
+@@ -0,0 +1,4 @@
++struct A() {
++	static immutable A a;
++}
++
+diff --git a/test/compilable/test16080.d b/test/compilable/test16080.d
+new file mode 100644
+index 000000000..a3cf503c8
+--- /dev/null
++++ b/test/compilable/test16080.d
+@@ -0,0 +1,6 @@
++// REQUIRED_ARGS: -lib -Icompilable/imports
++// EXTRA_SOURCES: extra-files/test16080b.d
++// https://issues.dlang.org/show_bug.cgi?id=16080
++
++import imp16080;
++
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0016-fix-issue-16229-don-t-use-alloca-for-huge-symbols.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0016-fix-issue-16229-don-t-use-alloca-for-huge-symbols.patch
@@ -1,0 +1,61 @@
+From 6dae748e0f36dddde9e679fc7fb7294afd3d95b2 Mon Sep 17 00:00:00 2001
+From: Rainer Schuetze <r.sagitario@gmx.de>
+Date: Sun, 3 Jul 2016 11:06:42 +0200
+Subject: [PATCH 16/21] fix issue 16229: don't use alloca for huge symbols
+
+---
+ src/backend/pdata.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/backend/pdata.c b/src/backend/pdata.c
+index e2b0067d9..dbf1fe3cd 100644
+--- a/src/backend/pdata.c
++++ b/src/backend/pdata.c
+@@ -39,6 +39,8 @@ static char __file__[] = __FILE__;      /* for tassert.h                */
+ Symbol *win64_unwind(Symbol *sf);
+ dt_t *unwind_data();
+ 
++#define ALLOCA_LIMIT 0x10000
++
+ /**********************************
+  * The .pdata section is used on Win64 by the VS debugger and dbghelp to get information
+  * to walk the stack and unwind exceptions.
+@@ -59,7 +61,7 @@ void win64_pdata(Symbol *sf)
+ 
+     // Generate the pdata name, which is $pdata$funcname
+     size_t sflen = strlen(sf->Sident);
+-    char *pdata_name = (char *)alloca(7 + sflen + 1);
++    char *pdata_name = (char *)(sflen < ALLOCA_LIMIT ? alloca(7 + sflen + 1) : malloc(7 + sflen + 1));
+     assert(pdata_name);
+     memcpy(pdata_name, "$pdata$", 7);
+     memcpy(pdata_name + 7, sf->Sident, sflen + 1);      // include terminating 0
+@@ -84,6 +86,8 @@ void win64_pdata(Symbol *sf)
+     spdata->Sseg = symbol_iscomdat(sf) ? MsCoffObj::seg_pdata_comdat(sf) : MsCoffObj::seg_pdata();
+     spdata->Salignment = 4;
+     outdata(spdata);
++
++    if (sflen >= ALLOCA_LIMIT) free(pdata_name);
+ }
+ 
+ /**************************************************
+@@ -98,7 +102,7 @@ Symbol *win64_unwind(Symbol *sf)
+ {
+     // Generate the unwind name, which is $unwind$funcname
+     size_t sflen = strlen(sf->Sident);
+-    char *unwind_name = (char *)alloca(8 + sflen + 1);
++    char *unwind_name = (char *)(sflen < ALLOCA_LIMIT ? alloca(8 + sflen + 1) : malloc(8 + sflen + 1));
+     assert(unwind_name);
+     memcpy(unwind_name, "$unwind$", 8);
+     memcpy(unwind_name + 8, sf->Sident, sflen + 1);     // include terminating 0
+@@ -111,6 +115,8 @@ Symbol *win64_unwind(Symbol *sf)
+     sunwind->Sseg = symbol_iscomdat(sf) ? MsCoffObj::seg_xdata_comdat(sf) : MsCoffObj::seg_xdata();
+     sunwind->Salignment = 1;
+     outdata(sunwind);
++
++    if (sflen >= ALLOCA_LIMIT) free(unwind_name);
+     return sunwind;
+ }
+ 
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0017-fix-Issue-16530-O-cov-interaction-leads-to-wrong-cod.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0017-fix-Issue-16530-O-cov-interaction-leads-to-wrong-cod.patch
@@ -1,0 +1,121 @@
+From d2e86ddd27c67ecd5dbc440349b8838902721904 Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Sat, 24 Sep 2016 05:27:26 -0700
+Subject: [PATCH 17/21] fix Issue 16530 - -O -cov interaction leads to wrong
+ codegen
+
+---
+ src/backend/cgcod.c    | 27 +++++++++++++++------------
+ test/runnable/test42.d | 42 +++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 56 insertions(+), 13 deletions(-)
+
+diff --git a/src/backend/cgcod.c b/src/backend/cgcod.c
+index 667437960..c7921a2ad 100644
+--- a/src/backend/cgcod.c
++++ b/src/backend/cgcod.c
+@@ -2279,20 +2279,23 @@ STATIC code * comsub(elem *e,regm_t *pretregs)
+     code* c = CNIL;
+     if (*pretregs == 0) goto done;        /* no possible side effects anyway */
+ 
+-    if (tyfloating(e->Ety) && config.inline8087)
+-        return comsub87(e,pretregs);
++    /* First construct a mask, emask, of all the registers that
++     * have the right contents.
++     */
++    emask = 0;
++    for (unsigned i = 0; i < arraysize(regcon.cse.value); i++)
++    {
++        //dbg_printf("regcon.cse.value[%d] = %p\n",i,regcon.cse.value[i]);
++        if (regcon.cse.value[i] == e)   // if contents are right
++                emask |= mask[i];       // turn on bit for reg
++    }
++    emask &= regcon.cse.mval;                     // make sure all bits are valid
+ 
+-  /* First construct a mask, emask, of all the registers that   */
+-  /* have the right contents.                                   */
++    if (emask & XMMREGS && *pretregs == mPSW)
++        ;
++    else if (tyfloating(e->Ety) && config.inline8087)
++        return comsub87(e,pretregs);
+ 
+-  emask = 0;
+-  for (unsigned i = 0; i < arraysize(regcon.cse.value); i++)
+-  {
+-        //dbg_printf("regcon.cse.value[%d] = %p\n",i,regcon.cse.value[i]);
+-        if (regcon.cse.value[i] == e)   /* if contents are right        */
+-                emask |= mask[i];       /* turn on bit for reg          */
+-  }
+-  emask &= regcon.cse.mval;                     /* make sure all bits are valid */
+ 
+   /* create mask of what's in csextab[] */
+   csemask = 0;
+diff --git a/test/runnable/test42.d b/test/runnable/test42.d
+index 6f4a712ea..ae4a5591a 100644
+--- a/test/runnable/test42.d
++++ b/test/runnable/test42.d
+@@ -5884,7 +5884,7 @@ void test11265()
+ 
+ struct TimeOfDay
+ {
+-    void roll(int value) 
++    void roll(int value)
+     {
+         value %= 60;
+         auto newVal = _seconds + value;
+@@ -6010,6 +6010,44 @@ void test14510()
+ }
+ 
+ /***************************************************/
++// https://issues.dlang.org/show_bug.cgi?id=16027
++
++void test16027()
++{
++    double value = 1.0;
++    value *= -1.0;
++    assert(value == -1.0);    // fails, value is +1.0
++
++    value = 1.0;
++    value = value * -1.0;
++    assert(value == -1.0);
++}
++
++/***************************************************/
++// https://issues.dlang.org/show_bug.cgi?id=16530
++
++double entropy2(double[] probs)
++{
++    double result = 0;
++    foreach (p; probs)
++    {
++        __gshared int x;
++        ++x;
++        if (!p) continue;
++        import std.math : log2;
++        result -= p * log2(p);
++    }
++    return result;
++}
++
++void test16530()
++{
++    import std.stdio;
++    if (entropy2([1.0, 0, 0]) != 0.0)
++       assert(0);
++}
++
++/***************************************************/
+ 
+ int main()
+ {
+@@ -6305,6 +6343,8 @@ int main()
+     test12138();
+     test14430();
+     test14510();
++    test16027();
++    test16530();
+ 
+     writefln("Success");
+     return 0;
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0018-fix-Issue-16699-REG-2.070-stack-corruption-with-scop.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0018-fix-Issue-16699-REG-2.070-stack-corruption-with-scop.patch
@@ -1,0 +1,83 @@
+From a1176668452bdc1940a1ac401247a3287fa39c7b Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Fri, 18 Nov 2016 02:11:04 -0800
+Subject: [PATCH 18/21] fix Issue 16699 - [REG 2.070] stack corruption with
+ scope(exit)
+
+---
+ src/backend/cgelem.c  |  2 +-
+ src/backend/el.c      |  2 +-
+ test/runnable/mars1.d | 24 ++++++++++++++++++++++++
+ 3 files changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/src/backend/cgelem.c b/src/backend/cgelem.c
+index 9eb38fbd4..aeeb9799e 100644
+--- a/src/backend/cgelem.c
++++ b/src/backend/cgelem.c
+@@ -5420,7 +5420,7 @@ elem *doptelem(elem *e, goal_t goal)
+ 
+     /* If entire expression is a struct, and we can replace it with     */
+     /* something simpler, do so.                                        */
+-    if (goal & GOALstruct && e && tybasic(e->Ety) == TYstruct)
++    if (goal & GOALstruct && e && (tybasic(e->Ety) == TYstruct || tybasic(e->Ety) == TYarray))
+         e = elstruct(e, goal);
+ 
+     return e;
+diff --git a/src/backend/el.c b/src/backend/el.c
+index 73ca303b2..6173edffe 100644
+--- a/src/backend/el.c
++++ b/src/backend/el.c
+@@ -3188,7 +3188,7 @@ void elem_print(elem *e)
+   else
+   {
+         if ((e->Eoper == OPstrpar || e->Eoper == OPstrctor || e->Eoper == OPstreq) ||
+-            e->Ety == TYstruct)
++            e->Ety == TYstruct || e->Ety == TYarray)
+             if (e->ET)
+                 dbg_printf("%d ", (int)type_size(e->ET));
+         WRTYxx(e->Ety);
+diff --git a/test/runnable/mars1.d b/test/runnable/mars1.d
+index 0d85662b9..71f9b7d67 100644
+--- a/test/runnable/mars1.d
++++ b/test/runnable/mars1.d
+@@ -1441,6 +1441,29 @@ void writeln(int v, int[] a)
+ 
+ ////////////////////////////////////////////////////////////////////////
+ 
++// https://issues.dlang.org/show_bug.cgi?id=16699
++
++ulong[1] parseDateRange()
++{
++    try
++    {
++        ulong[1] result;
++        result[0] = 6;
++        return result;
++    }
++    finally
++    {
++    }
++}
++
++void test16699()
++{
++    ulong[1] range = parseDateRange();
++    assert(range[0] == 6);
++}
++
++////////////////////////////////////////////////////////////////////////
++
+ int main()
+ {
+     testgoto();
+@@ -1491,6 +1514,7 @@ int main()
+     test15272();
+ 
+     test15629();
++    test16699();
+     printf("Success\n");
+     return 0;
+ }
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0019-fix-Issue-17215-ICE-cgcod.c-findreg-with-SIMD-and-O-.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0019-fix-Issue-17215-ICE-cgcod.c-findreg-with-SIMD-and-O-.patch
@@ -1,0 +1,45 @@
+From c50f8012d97fc3fed30872cd9c7bcb4234987786 Mon Sep 17 00:00:00 2001
+From: Martin Nowak <code@dawg.eu>
+Date: Fri, 24 Feb 2017 20:19:38 +0100
+Subject: [PATCH 19/21] fix Issue 17215 -  ICE(cgcod.c:findreg) with SIMD and
+ -O -inline
+
+- caused by assigning 2*REGSIZE XMM vectors partially
+- only triggers since SROA sees this 8 bytes access
+---
+ src/backend/cgelem.c        | 2 +-
+ test/compilable/test17215.d | 9 +++++++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+ create mode 100644 test/compilable/test17215.d
+
+diff --git a/src/backend/cgelem.c b/src/backend/cgelem.c
+index aeeb9799e..3e23f40c1 100644
+--- a/src/backend/cgelem.c
++++ b/src/backend/cgelem.c
+@@ -3578,7 +3578,7 @@ STATIC elem * eleq(elem *e, goal_t goal)
+             e1->Eoper == OPvar &&
+             e2->Eoper == OPvar &&
+             goal == GOALnone &&
+-            !tyfloating(e1->Ety)
++            !tyfloating(e1->Ety) && !tyvector(e1->Ety)
+            )
+         {
+             tym_t ty = (REGSIZE == 8) ? TYllong : TYint;
+diff --git a/test/compilable/test17215.d b/test/compilable/test17215.d
+new file mode 100644
+index 000000000..047039e76
+--- /dev/null
++++ b/test/compilable/test17215.d
+@@ -0,0 +1,9 @@
++// REQUIRED_ARGS: -O
++version (X86_64):
++alias vec = __vector(int[4]);
++
++vec binop(vec a)
++{
++    vec b = a;
++    return b;
++}
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0020-fix-Issue-16854-Inline-assembler-has-VMOVLHPS-and-VM.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0020-fix-Issue-16854-Inline-assembler-has-VMOVLHPS-and-VM.patch
@@ -1,0 +1,56 @@
+From 01a9538bd37b8e8335e86195fb3ad6ce0d069fcc Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Tue, 29 Nov 2016 17:31:11 -0800
+Subject: [PATCH 20/21] fix Issue 16854 - Inline assembler has VMOVLHPS and
+ VMOVHLPS swapped
+
+---
+ src/backend/ptrntab.c  | 4 ++--
+ test/runnable/iasm64.d | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/backend/ptrntab.c b/src/backend/ptrntab.c
+index 9cfc2c09b..72122ae2e 100644
+--- a/src/backend/ptrntab.c
++++ b/src/backend/ptrntab.c
+@@ -5516,10 +5516,10 @@ PTRNTAB2 aptb2SHA256MSG2[] = /* SHA256MSG2 */ {
+         X("vmovddup",       2,              (P) aptb2VMOVDDUP )             \
+         X("vmovdqa",        2,              (P) aptb2VMOVDQA )              \
+         X("vmovdqu",        2,              (P) aptb2VMOVDQU )              \
+-        X("vmovhlps",       3,              (P) aptb3VMOVLHPS )             \
++        X("vmovhlps",       3,              (P) aptb3VMOVHLPS )             \
+         X("vmovhpd",        ITopt | 3,      (P) aptb3VMOVHPD )              \
+         X("vmovhps",        ITopt | 3,      (P) aptb3VMOVHPS )              \
+-        X("vmovlhps",       3,              (P) aptb3VMOVHLPS )             \
++        X("vmovlhps",       3,              (P) aptb3VMOVLHPS )             \
+         X("vmovlpd",        ITopt | 3,      (P) aptb3VMOVLPD )              \
+         X("vmovlps",        ITopt | 3,      (P) aptb3VMOVLPS )              \
+         X("vmovmskpd",      2,              (P) aptb2VMOVMSKPD )            \
+diff --git a/test/runnable/iasm64.d b/test/runnable/iasm64.d
+index 679c2614d..b66482367 100644
+--- a/test/runnable/iasm64.d
++++ b/test/runnable/iasm64.d
+@@ -5180,8 +5180,8 @@ void test61()
+         0xC5, 0xFE, 0x6F, 0xC0,                   // vmovdqu YMM0, YMM0;
+         0xC5, 0xFE, 0x7F, 0x00,                   // vmovdqu [RAX],YMM0;
+ 
+-        0xC5, 0xF8, 0x12, 0xC0,                   // vmovlhps XMM0, XMM0, XMM0;
+-        0xC5, 0xF8, 0x16, 0xC0,                   // vmovhlps XMM0, XMM0, XMM0;
++        0xC5, 0xF8, 0x12, 0xC0,                   // vmovhlps XMM0, XMM0, XMM0;
++        0xC5, 0xF8, 0x16, 0xC0,                   // vmovlhps XMM0, XMM0, XMM0;
+ 
+         0xC5, 0xF9, 0x16, 0x00,                   // vmovhpd XMM0, XMM0, [RAX];
+         0xC5, 0xF9, 0x17, 0x00,                   // vmovhpd [RAX], XMM0;
+@@ -5968,8 +5968,8 @@ void test61()
+         vmovdqu YMM0, YMM0;
+         vmovdqu [RAX],YMM0;
+ 
+-        vmovlhps XMM0, XMM0, XMM0;
+         vmovhlps XMM0, XMM0, XMM0;
++        vmovlhps XMM0, XMM0, XMM0;
+ 
+         vmovhpd XMM0, XMM0, [RAX];
+         vmovhpd [RAX], XMM0;
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/dmd/0021-fix-Issue-14613-DMD-Internal-error-backend-cod1.c-15.patch
+++ b/docker/dlang/dmd-transitional-patches/dmd/0021-fix-Issue-14613-DMD-Internal-error-backend-cod1.c-15.patch
@@ -1,0 +1,97 @@
+From 6f679e70cf5f80dac2b051928a2c940b004411bc Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Sun, 30 Oct 2016 02:06:49 -0700
+Subject: [PATCH 21/21] fix Issue 14613 - DMD: Internal error: backend/cod1.c
+ 1567 on '-O' switch
+
+---
+ src/backend/cgcod.c       |  5 +++++
+ src/backend/cod1.c        | 15 +++++++++++----
+ test/runnable/test14613.d | 19 +++++++++++++++++++
+ 3 files changed, 35 insertions(+), 4 deletions(-)
+ create mode 100644 test/runnable/test14613.d
+
+diff --git a/src/backend/cgcod.c b/src/backend/cgcod.c
+index c7921a2ad..716b5dbeb 100644
+--- a/src/backend/cgcod.c
++++ b/src/backend/cgcod.c
+@@ -1834,6 +1834,9 @@ code *allocreg(regm_t *pretregs,unsigned *preg,tym_t tym
+         unsigned size = tysize[tym];
+         *pretregs &= mES | allregs | XMMREGS;
+         regm_t retregs = *pretregs;
++#ifdef DEBUG
++if (retregs == 0) printf("allocreg: file %s(%d)\n", file, line);
++#endif
+         if ((retregs & regcon.mvar) == retregs) // if exactly in reg vars
+         {
+             if (size <= REGSIZE || (retregs & XMMREGS))
+@@ -2293,6 +2296,8 @@ STATIC code * comsub(elem *e,regm_t *pretregs)
+ 
+     if (emask & XMMREGS && *pretregs == mPSW)
+         ;
++    else if (tyxmmreg(e->Ety) && config.fpxmmregs)
++        ;
+     else if (tyfloating(e->Ety) && config.inline8087)
+         return comsub87(e,pretregs);
+ 
+diff --git a/src/backend/cod1.c b/src/backend/cod1.c
+index d96ac6aad..fcf95b4bc 100644
+--- a/src/backend/cod1.c
++++ b/src/backend/cod1.c
+@@ -1809,7 +1809,14 @@ code *fixresult(elem *e,regm_t retregs,regm_t *pretregs)
+         retregs = *pretregs & ~mPSW;
+   }
+   if (forccs)                           /* if return result in flags    */
+-        c = cat(c,tstresult(retregs,tym,forregs));
++  {
++        code *cf;
++        if (retregs & (mST01 | mST0))
++            cf = fixresult87(e,retregs,pretregs);
++        else
++            cf = tstresult(retregs,tym,forregs);
++        c = cat(c, cf);
++  }
+   return c;
+ }
+ 
+@@ -4488,9 +4495,9 @@ code *loaddata(elem *e,regm_t *pretregs)
+   regm_t flags,forregs,regm;
+ 
+ #ifdef DEBUG
+-  if (debugw)
+-        printf("loaddata(e = %p,*pretregs = %s)\n",e,regm_str(*pretregs));
+-  //elem_print(e);
++//  if (debugw)
++//        printf("loaddata(e = %p,*pretregs = %s)\n",e,regm_str(*pretregs));
++//  elem_print(e);
+ #endif
+   assert(e);
+   elem_debug(e);
+diff --git a/test/runnable/test14613.d b/test/runnable/test14613.d
+new file mode 100644
+index 000000000..6b1e39a02
+--- /dev/null
++++ b/test/runnable/test14613.d
+@@ -0,0 +1,19 @@
++
++// https://issues.dlang.org/show_bug.cgi?id=14613
++
++T foo(T)(T b)
++{
++    return (b / (b == 0)) == 0;
++}
++
++void main()
++{
++    assert(foo(0.0f) == 1.0f);
++    assert(foo(1.0f) == 0.0f);
++
++    assert(foo(0.0) == 1.0);
++    assert(foo(1.0) == 0.0);
++
++    assert(foo(0.0L) == 1.0L);
++    assert(foo(1.0L) == 0.0L);
++}
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/druntime/0015-Add-bindings-for-POSIX-getdelim-and-getline.patch
+++ b/docker/dlang/dmd-transitional-patches/druntime/0015-Add-bindings-for-POSIX-getdelim-and-getline.patch
@@ -1,0 +1,24 @@
+From 822813dd259c0341a99f78ac6e8ddffdd91bfbe3 Mon Sep 17 00:00:00 2001
+From: Nemanja Boric <nemanja.boric@sociomantic.com>
+Date: Thu, 26 Jan 2017 18:52:49 +0100
+Subject: [PATCH] Add bindings for POSIX getdelim and getline
+
+---
+ src/core/sys/posix/stdio.d | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/core/sys/posix/stdio.d b/src/core/sys/posix/stdio.d
+index 122cba07..6cc30a99 100644
+--- a/src/core/sys/posix/stdio.d
++++ b/src/core/sys/posix/stdio.d
+@@ -321,3 +321,7 @@ unittest
+     assert(memcmp(ptr, testdata.ptr, testdata.length*wchar_t.sizeof) == 0);
+     assert(fclose(f) == 0);
+ }
++
++
++ssize_t getdelim (char** lineptr, size_t* n, int delimiter, FILE* stream);
++ssize_t getline (char** lineptr, size_t* n, FILE* stream);
+-- 
+2.12.1
+

--- a/docker/dlang/dmd-transitional-patches/druntime/0016-Add-eventfd-bindings.patch
+++ b/docker/dlang/dmd-transitional-patches/druntime/0016-Add-eventfd-bindings.patch
@@ -1,0 +1,150 @@
+From e4b0121edaf47139ffe4af27f126767536fa6a42 Mon Sep 17 00:00:00 2001
+From: Nemanja Boric <nemanja.boric@sociomantic.com>
+Date: Tue, 4 Apr 2017 15:27:57 +0200
+Subject: [PATCH] Add eventfd bindings
+
+This adds bindings for linux-specific eventfd_* calls.
+
+Cherry-pick of https://github.com/dlang/druntime/pull/1800/commits/0748d402f4dcff657eecc4f383acc9b4a9641de5
+---
+ mak/COPY                         |  1 +
+ src/core/sys/linux/sys/eventfd.d | 85 ++++++++++++++++++++++++++++++++++++++++
+ win32.mak                        |  3 ++
+ win64.mak                        |  3 ++
+ 4 files changed, 92 insertions(+)
+ create mode 100644 src/core/sys/linux/sys/eventfd.d
+
+diff --git a/mak/COPY b/mak/COPY
+index 4fe11f25..e36d1a2a 100644
+--- a/mak/COPY
++++ b/mak/COPY
+@@ -72,6 +72,7 @@ COPY=\
+ 	$(IMPDIR)\core\sys\linux\tipc.d \
+ 	$(IMPDIR)\core\sys\linux\unistd.d \
+ 	\
++	$(IMPDIR)\core\sys\linux\sys\eventfd.d \
+ 	$(IMPDIR)\core\sys\linux\sys\inotify.d \
+ 	$(IMPDIR)\core\sys\linux\sys\mman.d \
+ 	$(IMPDIR)\core\sys\linux\sys\netinet\tcp.d \
+diff --git a/src/core/sys/linux/sys/eventfd.d b/src/core/sys/linux/sys/eventfd.d
+new file mode 100644
+index 00000000..f0e56195
+--- /dev/null
++++ b/src/core/sys/linux/sys/eventfd.d
+@@ -0,0 +1,85 @@
++/**
++ * D header file for GNU/Linux.
++ *
++ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
++ * Authors:   Nemanja Boric
++ */
++module core.sys.linux.sys.eventfd;
++
++version (linux):
++extern (C):
++@nogc:
++@system:
++nothrow:
++
++import core.stdc.stdint: uint64_t;
++
++/// Type for the event counter
++alias uint64_t eventfd_t;
++
++/* Return file descriptor for generic event channel.  Set initial
++   value to count.  */
++int eventfd (uint count, int flags);
++
++/* Read event counter and possibly wait for events.  */
++int eventfd_read (int fd, eventfd_t* value);
++
++/* Increment event counter.  */
++int eventfd_write (int fd, eventfd_t value);
++
++version (X86)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x800; // octal!4000
++}
++else version (X86_64)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x800; // octal!4000
++}
++else version (MIPS32)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x80; // octal!200
++}
++else version (MIPS64)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x80; // octal!200
++}
++else version (PPC)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x800; // octal!4000
++}
++else version (PPC64)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x800; // octal!4000
++}
++else version (ARM)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x800; // octal!4000
++}
++else version (AArch64)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x800; // octal!4000
++}
++else version (SystemZ)
++{
++    enum EFD_SEMAPHORE = 1;
++    enum EFD_CLOEXEC = 0x80000; // octal!2000000
++    enum EFD_NONBLOCK = 0x800; // octal!4000
++}
++else
++    static assert(0, "unimplemented");
+diff --git a/win32.mak b/win32.mak
+index f54c6ba4..cc837563 100644
+--- a/win32.mak
++++ b/win32.mak
+@@ -415,6 +415,9 @@ $(IMPDIR)\core\sys\linux\tipc.d : src\core\sys\linux\tipc.d
+ $(IMPDIR)\core\sys\linux\unistd.d : src\core\sys\linux\unistd.d
+ 	copy $** $@
+ 
++$(IMPDIR)\core\sys\linux\sys\eventfd.d : src\core\sys\linux\sys\eventfd.d
++	copy $** $@
++
+ $(IMPDIR)\core\sys\linux\sys\inotify.d : src\core\sys\linux\sys\inotify.d
+ 	copy $** $@
+ 
+diff --git a/win64.mak b/win64.mak
+index 3ef7f107..7454955c 100644
+--- a/win64.mak
++++ b/win64.mak
+@@ -423,6 +423,9 @@ $(IMPDIR)\core\sys\linux\tipc.d : src\core\sys\linux\tipc.d
+ $(IMPDIR)\core\sys\linux\unistd.d : src\core\sys\linux\unistd.d
+ 	copy $** $@
+ 
++$(IMPDIR)\core\sys\linux\sys\eventfd.d : src\core\sys\linux\sys\eventfd.d
++	copy $** $@
++
+ $(IMPDIR)\core\sys\linux\sys\inotify.d : src\core\sys\linux\sys\inotify.d
+ 	copy $** $@
+ 
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/druntime/0017-Add-Fiber-s-guard-page-in-Posix-as-well.patch
+++ b/docker/dlang/dmd-transitional-patches/druntime/0017-Add-Fiber-s-guard-page-in-Posix-as-well.patch
@@ -1,0 +1,198 @@
+From 9893aefd4dd16c14e7198fa82c314bcdeb4e9d0e Mon Sep 17 00:00:00 2001
+From: Nemanja Boric <nemanja.boric@sociomantic.com>
+Date: Thu, 24 Nov 2016 17:25:39 +0100
+Subject: [PATCH] Add Fiber's guard page in Posix as well
+
+Windows Fiber implementation already uses the fiber stack guard page.
+This brings the similar protection for mmaped fiber stacks, using
+mprotect.
+
+This allows configuring the size or turning off completely
+the fiber's stack's guard page. It can be configured using new
+Fiber's constructor's parameter `guard_page_size`.
+---
+ changelog/fiber-configure.dd |  6 +++++
+ changelog/fiber.dd           |  9 +++++++
+ src/core/thread.d            | 61 ++++++++++++++++++++++++++++++++++----------
+ 3 files changed, 62 insertions(+), 14 deletions(-)
+ create mode 100644 changelog/fiber-configure.dd
+ create mode 100644 changelog/fiber.dd
+
+diff --git a/changelog/fiber-configure.dd b/changelog/fiber-configure.dd
+new file mode 100644
+index 00000000..23267356
+--- /dev/null
++++ b/changelog/fiber-configure.dd
+@@ -0,0 +1,6 @@
++Make fiber stack protection-page size configurable
++
++It is now possible to change the guard page size by using
++the new Fiber's constructor argument - guard_page_size. It defaults to
++`PAGE_SIZE` (the same it used to be on Windows), and specifying 0 will
++turn this feature off.
+diff --git a/changelog/fiber.dd b/changelog/fiber.dd
+new file mode 100644
+index 00000000..926dfa1f
+--- /dev/null
++++ b/changelog/fiber.dd
+@@ -0,0 +1,9 @@
++Add Fiber's stack-protection page for Posix.
++
++The feature already existing for Windows' fiber implementation is now added to
++the systems using mmap to allocate fibers' stacks: After (or before) the last
++page used for the Fiber's stack, the page is allocate which is protected for
++any kind of access. This will cause system to trap immediately on the fiber's
++stack overflow. If in debugger session, one can inspect contents of the memory
++before or after stack pointer and it can be seen if it contains END OF FIBER
++string pattern.
+diff --git a/src/core/thread.d b/src/core/thread.d
+index 88b7708f..52c5b426 100644
+--- a/src/core/thread.d
++++ b/src/core/thread.d
+@@ -3937,18 +3937,21 @@ class Fiber
+      * Params:
+      *  fn = The fiber function.
+      *  sz = The stack size for this fiber.
++     *  guard_page_size = size of the guard page to trap fiber's stack
++     *                    overflows
+      *
+      * In:
+      *  fn must not be null.
+      */
+-    this( void function() fn, size_t sz = PAGESIZE*4 ) nothrow
++    this( void function() fn, size_t sz = PAGESIZE*4,
++          size_t guard_page_size = PAGESIZE ) nothrow
+     in
+     {
+         assert( fn );
+     }
+     body
+     {
+-        allocStack( sz );
++        allocStack( sz, guard_page_size );
+         reset( fn );
+     }
+ 
+@@ -3960,18 +3963,21 @@ class Fiber
+      * Params:
+      *  dg = The fiber function.
+      *  sz = The stack size for this fiber.
++     *  guard_page_size = size of the guard page to trap fiber's stack
++     *                    overflows
+      *
+      * In:
+      *  dg must not be null.
+      */
+-    this( void delegate() dg, size_t sz = PAGESIZE*4 ) nothrow
++    this( void delegate() dg, size_t sz = PAGESIZE*4,
++          size_t guard_page_size = PAGESIZE ) nothrow
+     in
+     {
+         assert( dg );
+     }
+     body
+     {
+-        allocStack( sz );
++        allocStack( sz, guard_page_size);
+         reset( dg );
+     }
+ 
+@@ -4311,7 +4317,7 @@ private:
+     //
+     // Allocate a new stack for this fiber.
+     //
+-    final void allocStack( size_t sz ) nothrow
++    final void allocStack( size_t sz, size_t guard_page_size ) nothrow
+     in
+     {
+         assert( !m_pmem && !m_ctxt );
+@@ -4336,7 +4342,7 @@ private:
+         {
+             // reserve memory for stack
+             m_pmem = VirtualAlloc( null,
+-                                   sz + PAGESIZE,
++                                   sz + guard_page_size,
+                                    MEM_RESERVE,
+                                    PAGE_NOACCESS );
+             if( !m_pmem )
+@@ -4344,7 +4350,7 @@ private:
+ 
+             version( StackGrowsDown )
+             {
+-                void* stack = m_pmem + PAGESIZE;
++                void* stack = m_pmem + guard_page_size;
+                 void* guard = m_pmem;
+                 void* pbase = stack + sz;
+             }
+@@ -4363,13 +4369,16 @@ private:
+             if( !stack )
+                 onOutOfMemoryError();
+ 
+-            // allocate reserved guard page
+-            guard = VirtualAlloc( guard,
+-                                  PAGESIZE,
+-                                  MEM_COMMIT,
+-                                  PAGE_READWRITE | PAGE_GUARD );
+-            if( !guard )
+-                onOutOfMemoryError();
++            if (guard_page_size)
++            {
++                // allocate reserved guard page
++                guard = VirtualAlloc( guard,
++                                      guard_page_size,
++                                      MEM_COMMIT,
++                                      PAGE_READWRITE | PAGE_GUARD );
++                if( !guard )
++                    onOutOfMemoryError();
++            }
+ 
+             m_ctxt.bstack = pbase;
+             m_ctxt.tstack = pbase;
+@@ -4384,6 +4393,9 @@ private:
+ 
+             static if( __traits( compiles, mmap ) )
+             {
++                // Allocate more for the memory guard
++                sz += guard_page_size;
++
+                 m_pmem = mmap( null,
+                                sz,
+                                PROT_READ | PROT_WRITE,
+@@ -4413,13 +4425,34 @@ private:
+             {
+                 m_ctxt.bstack = m_pmem + sz;
+                 m_ctxt.tstack = m_pmem + sz;
++                void* guard = m_pmem;
+             }
+             else
+             {
+                 m_ctxt.bstack = m_pmem;
+                 m_ctxt.tstack = m_pmem;
++                void* guard = m_pmem + sz - guard_page_size;
+             }
+             m_size = sz;
++
++            static if( __traits( compiles, mmap ) )
++            {
++                if (guard_page_size)
++                {
++                    // Mark end of stack
++                    for ( ubyte* g = cast(ubyte*)guard; g < guard + guard_page_size; g+= 32)
++                        g[0 .. 32] = cast(ubyte[]) "END OF FIBER -- END OF FIBER -- ";
++
++                    // protect end of stack
++                    if ( mprotect(guard, guard_page_size, PROT_NONE) == -1 )
++                        abort();
++                }
++            }
++            else
++            {
++                // Supported only for mmap allocated memory - results are
++                // undefined if applied to memory not obtained by mmap
++            }
+         }
+ 
+         Thread.add( m_ctxt );
+-- 
+2.12.2
+

--- a/docker/dlang/dmd-transitional-patches/druntime/0018-Disable-copying-of-inotify_event.patch
+++ b/docker/dlang/dmd-transitional-patches/druntime/0018-Disable-copying-of-inotify_event.patch
@@ -1,0 +1,26 @@
+From 1ff484991829209f6eb265b5b4f4d9fc141f5f0f Mon Sep 17 00:00:00 2001
+From: Mihails Strasuns <mihails.strasuns@gmail.com>
+Date: Fri, 28 Apr 2017 17:04:15 +0200
+Subject: [PATCH] Disable copying of inotify_event
+
+Pick of https://github.com/dlang/druntime/pull/1795
+---
+ src/core/sys/linux/sys/inotify.d | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/core/sys/linux/sys/inotify.d b/src/core/sys/linux/sys/inotify.d
+index 41ad65c2..0e273c63 100644
+--- a/src/core/sys/linux/sys/inotify.d
++++ b/src/core/sys/linux/sys/inotify.d
+@@ -18,6 +18,8 @@ struct inotify_event
+     uint cookie;
+     uint len;
+     char[0] name;
++
++    @disable this(this);
+ }
+ 
+ enum: uint
+-- 
+2.12.2
+


### PR DESCRIPTION
Plain copy of all patches used in latest dmd-transitional release
distributed internally.