### PR TITLE
Update jfrog to v1.10.3 and fpm to v1.9.x

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     VERSION_IMAGE=$VERSION_IMAGE \
     VERSION_FPM=1.8.x \
     # jfrog doesn't support 1.8.x format yet
-    VERSION_JFROG=1.9.0 \
+    VERSION_JFROG=1.10.3 \
     VERSION_TRAVIS=1.8.x
 
 LABEL \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # Environment variables for program and image versions
     # (scripts use them to know which version to install)
     VERSION_IMAGE=$VERSION_IMAGE \
-    VERSION_FPM=1.8.x \
+    VERSION_FPM=1.9.x \
     VERSION_TRAVIS=1.8.x \
     # jfrog doesn't support 1.8.x format yet
     VERSION_JFROG=1.10.3

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -7,9 +7,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # (scripts use them to know which version to install)
     VERSION_IMAGE=$VERSION_IMAGE \
     VERSION_FPM=1.8.x \
+    VERSION_TRAVIS=1.8.x \
     # jfrog doesn't support 1.8.x format yet
-    VERSION_JFROG=1.10.3 \
-    VERSION_TRAVIS=1.8.x
+    VERSION_JFROG=1.10.3
 
 LABEL \
     maintainer="Sociomantic Labs GmbH <tsunami@sociomantic.com>" \


### PR DESCRIPTION
This should fix the NOP --vcs-tag option (https://github.com/JFrogDev/jfrog-cli-go/issues/55).