### PR TITLE
Don't install git PPA or specify git version

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -6,7 +6,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # Environment variables for program and image versions
     # (scripts use them to know which version to install)
     VERSION_IMAGE=$VERSION_IMAGE \
-    VERSION_GIT=1:2.13.x \
     VERSION_FPM=1.8.x \
     # jfrog doesn't support 1.8.x format yet
     VERSION_JFROG=1.9.0 \
@@ -17,7 +16,6 @@ LABEL \
     description="Base image for Sociomantic Labs projects" \
     # Labels for programs and image versions
     com.sociomantic.version.image=$VERSION_IMAGE \
-    com.sociomantic.version.git=$VERSION_GIT \
     com.sociomantic.version.fpm=$VERSION_FPM \
     com.sociomantic.version.jfrog=$VERSION_JFROG \
     com.sociomantic.version.travis=$VERSION_TRAVIS

--- a/docker/base
+++ b/docker/base
@@ -10,15 +10,12 @@ echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/99no-recommends
 # Make sure our packages list is updated
 apt-get update
 
-# We install an up to date git version because we might be using commands only
-# present in modern versions. For this we need python-software-properties /
-# software-properties-common packages that provide add-apt-repository (for
-# easily installing PPAs).
+# We install some basic packages first.
 apt-get -y install apt-transport-https build-essential bzip2 devscripts \
 	sudo debhelper less lsb-release vim wget curl adduser fakeroot \
 	python3 python-docutils python-pil python-pygments \
 	python-software-properties software-properties-common \
-	ruby-dev rubygems-integration jq
+	ruby-dev rubygems-integration jq git
 
 # Add extra APT repositories from Sociomantic in Bintray
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
@@ -36,17 +33,11 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EBCF975E5BA24D5E
 wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list \
 		-O /etc/apt/sources.list.d/d-apt.list
 
-# Add a PPA for the latest Git
-add-apt-repository -y ppa:git-core/ppa
-
 # Get the new packages list
 apt-get update
 
 # Update the whole system
 apt-get -y dist-upgrade
-
-# Install git from the PPA
-apt-get -y install "$(apt_ver git "$VERSION_GIT")"
 
 # fpm installation is release-dependant
 gem install $(gem_ver travis "$VERSION_TRAVIS")


### PR DESCRIPTION
Is not really that common to need a bleeding edge git version any more, and using the PPA means a more unstable version that could prevent cachalot from building when a version is phased out.