### PR TITLE
Remove trusty support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
         - BRANCH="$TRAVIS_BRANCH"
         - TAG="$TRAVIS_TAG"
     matrix:
-        - DIST=trusty
         - DIST=xenial
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # =============
 
 # Default distributions to build
-DIST ?= trusty xenial
+DIST ?= xenial
 
 # Default DockerHub organization to use to tag (/push) images
 DOCKER_ORG ?= sociomantictsunami
@@ -76,7 +76,6 @@ $(foreach d,$(DIST),$(foreach i,$(IMAGES),$(eval $(call create_recipe,$i,$d))))
 
 # Dependencies
 # TODO: Generate from Dockerfiles
-.dlang.trusty.stamp: .base.trusty.stamp
 .dlang.xenial.stamp: .base.xenial.stamp
 
 .PHONY: pre-test

--- a/build-img
+++ b/build-img
@@ -24,8 +24,8 @@ Options:
 
 Examples:
 
-# builds sociomantictsunami/base:v2-trusty image based on base.Dockerfile
-$0 sociomantictsunami/base:v2-trusty
+# builds sociomantictsunami/base:v2-xenial image based on base.Dockerfile
+$0 sociomantictsunami/base:v2-xenial
 HELP
 }
 

--- a/docker/base
+++ b/docker/base
@@ -8,10 +8,10 @@ set -xeu
 echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/99no-recommends
 
 # Make sure our packages list is updated
-apt-get update
+apt update
 
 # We install some basic packages first.
-apt-get -y install apt-transport-https build-essential bzip2 devscripts \
+apt -y install apt-transport-https build-essential bzip2 devscripts \
 	sudo debhelper less lsb-release vim wget curl adduser fakeroot \
 	python3 python-docutils python-pil python-pygments \
 	python-software-properties software-properties-common \
@@ -34,10 +34,10 @@ wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list \
 		-O /etc/apt/sources.list.d/d-apt.list
 
 # Get the new packages list
-apt-get update
+apt update
 
 # Update the whole system
-apt-get -y dist-upgrade
+apt -y full-upgrade
 
 # fpm installation is release-dependant
 gem install $(gem_ver travis "$VERSION_TRAVIS")

--- a/docker/dlang
+++ b/docker/dlang
@@ -4,9 +4,9 @@ set -xeu
 # Get utility stuff
 . ./util.sh
 
-apt-get update
+apt update
 
-apt-get -y install \
+apt -y install \
 	"$(apt_ver libebtree6 "$VERSION_EBTREE")" \
 		"$(apt_ver libebtree6-dbg "$VERSION_EBTREE")" \
 		"$(apt_ver libebtree6-dev "$VERSION_EBTREE")" \


### PR DESCRIPTION
Trusty is quite old by now and Xenial has been out there for quite some time too, so is enough to only support the latest LTS.

This also replaces the use of apt-get with apt, which is a more modern alternative to apt-get. We also use full-upgrade instead of dist-upgrade, which is more like what we want.