### PR TITLE
Add descriptions to the installed tools

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -10,9 +10,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # Environment variables for program and image versions
     # (scripts use them to know which version to install)
     VERSION_IMAGE=$VERSION_IMAGE \
+    # fpm is a tool to easily build Debian packages
+    # https://fpm.readthedocs.io/en/latest/
     VERSION_FPM=1.9.x \
+    # travis is a command-line inteface to the travis CI service
+    # https://github.com/travis-ci/travis.rb#the-travis-client-
     VERSION_TRAVIS=1.8.x \
-    # jfrog doesn't support 1.8.x format yet
+    # jfrog is a command-line interface to JFrog's Bintray apt repo service
+    # https://www.jfrog.com/confluence/display/CLI/JFrog+CLI
+    # jfrog doesn't support 1.8.x format yet, a full version must be specified
     VERSION_JFROG=1.10.3
 
 LABEL \


### PR DESCRIPTION
Coming from #6, cachalot installs a lot of external tools, wehre some of them are not very wideknown. Perhaps adding comments to https://github.com/sociomantic-tsunami/cachalot/blob/v2/base.Dockerfile and similar places, or inside the readme (which is unsound, since it would require remembering we need to update it) will make things trivially obvious to the most causal observer.