### PR TITLE
Add pre-release repos and dlang community repo

### DIFF
--- a/docker/base
+++ b/docker/base
@@ -32,7 +32,7 @@ echo '# Sociomantic Tsunami repos' \
 dist="$(lsb_release -cs)"
 for r in tools dlang
 do
-	echo "deb https://dl.bintray.com/sociomantic-tsunami/$r $dist release" \
+	echo "deb https://dl.bintray.com/sociomantic-tsunami/$r $dist release prerelease" \
 		>> /etc/apt/sources.list.d/sociomantic-tsunami.list
 done
 
@@ -40,6 +40,9 @@ done
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EBCF975E5BA24D5E
 wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list \
 		-O /etc/apt/sources.list.d/d-apt.list
+
+# Add apt_preferences file
+cp -v base-apt-preferences /etc/apt/preferences.d/cachalot
 
 # Get the new packages list
 apt update

--- a/docker/base-apt-preferences
+++ b/docker/base-apt-preferences
@@ -1,0 +1,7 @@
+Package: *
+Pin: release o=Bintray,a=xenial,c=release
+Pin-Priority: 900
+
+Package: *
+Pin: release o=Bintray,a=xenial,c=prerelease
+Pin-Priority: -50

--- a/docker/dlang
+++ b/docker/dlang
@@ -8,6 +8,14 @@ set -xeu
 # Get utility stuff
 . ./util.sh
 
+dist="$(lsb_release -cs)"
+
+# Add extra dlang-community APT repository (also in Bintray)
+echo '# dlang-community repos' \
+        > /etc/apt/sources.list.d/dlang-community.list
+echo "deb https://dl.bintray.com/dlang-community/apt $dist release prerelease" \
+        >> /etc/apt/sources.list.d/dlang-community.list
+
 # Install dlang packages
 apt update
 apt_pin_install \


### PR DESCRIPTION
The dlang community repo is a cherry-pick from v4 because that's not really a breaking change (in the liberal sense).