### PR TITLE
Install SSH client into the base image

### DIFF
--- a/docker/base
+++ b/docker/base
@@ -19,7 +19,7 @@ apt -y install apt-transport-https build-essential bzip2 devscripts \
 	sudo debhelper less lsb-release vim wget curl adduser fakeroot \
 	python3 python-docutils python-pil python-pygments \
 	python-software-properties software-properties-common \
-	ruby-dev rubygems-integration jq git
+	ruby-dev rubygems-integration jq git openssh-client
 
 # Configure default Git username and e-mail
 git config --system user.name "Cachalot Docker image"


### PR DESCRIPTION
Required to clone SSH-based git URLs