### PR TITLE
Don't push all tags of a certain image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ ifdef TAG
 endif
 # Push the latest only if is not a pre-release tag
 ifeq ($(LATEST_DIST),$2$(findstring -,$(TAG)))
-	docker push "$(DOCKER_ORG)/$1"
+	docker push "$(DOCKER_ORG)/$1:latest"
 endif
 
 .PHONY: test-$1.$2


### PR DESCRIPTION
The `docker push img` format, without specifying a tag, pushes all tags
for that image, which is not exactly what we want (we just want to push
the `latest` tag).