### PR TITLE
Add a way to add extra docker build arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifneq ($$(__dep_$1.$2),)
 endif
 
 .$1.$2.stamp: $1.Dockerfile $(wildcard docker/*)
-	./build-img $(if $(TAG),-V "$(TAG)") "$(DOCKER_ORG)/$1:$2-$(docker_tag)"
+	./build-img $(if $(TAG),-V "$(TAG)") "$(DOCKER_ORG)/$1:$2-$(docker_tag)" $(BUILD_ARGS) $($1.$2.BUILD_ARGS)
 ifdef TAG
 	@printf "\n"
 	docker tag "$(DOCKER_ORG)/$1:$2-$(docker_tag)" "$(DOCKER_ORG)/$1:$2-$(TAG)"

--- a/build-img
+++ b/build-img
@@ -45,10 +45,10 @@ do
 done
 shift `expr $OPTIND - 1`
 
-test $# -lt 2 || {
+test $# -ge 1 || {
 	print_usage >&2
 	echo >&2
-	echo "Incorrect number of arguments" >&2
+	echo "We need at least one argument: IMAGE (got none)!" >&2
 	exit 2
 }
 

--- a/relnotes/build-args.feature.md
+++ b/relnotes/build-args.feature.md
@@ -1,0 +1,15 @@
+### Add extra docker build arguments
+
+Now extra build arguments can be passed to docker build via the `Makefile` by
+defining some new special variables. To add global build args (passed when
+building all images), use `$(BUILD_ARGS)`. If you want to pass extra build args
+to just one particular image, you can use `$({IMAGE}.{DIST}.BUILD_ARGS)`, where
+`{IMAGE}` is the name of the image and `{DIST}` is the name of the dist.
+
+For example:
+
+```make
+BUILD_ARGS := --quiet
+
+dlang.xenial.BUILD_ARGS := --build-arg DMD_VER=1.081.*
+```


### PR DESCRIPTION
Now extra build arguments can be passed to docker build via the `Makefile` by defining some new special variables. To add global build args (passed when building all images), use `$(BUILD_ARGS)`. If you want to pass extra build args to just one particular image, you can use `$({IMAGE}.{DIST}.BUILD_ARGS)`, where `{IMAGE}` is the name of the image and `{DIST}` is the name of the dist.

For example:

```make
BUILD_ARGS := --quiet

dlang.xenial.BUILD_ARGS := --build-arg DMD_VER=1.081.*
```