### PR TITLE
dlang: Add new ebtree bintray repo

### DIFF
--- a/docker/dlang
+++ b/docker/dlang
@@ -12,6 +12,8 @@ dist="$(lsb_release -cs)"
 
 # Add extra dlang APT repositories from Sociomantic in Bintray
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+echo "deb https://dl.bintray.com/sociomantic-tsunami/ebtree $dist release prerelease" \
+        >> /etc/apt/sources.list.d/sociomantic-tsunami.list
 echo "deb https://dl.bintray.com/sociomantic-tsunami/dlang $dist release prerelease" \
         >> /etc/apt/sources.list.d/sociomantic-tsunami.list
 

--- a/relnotes/ebtree-repo.feature.md
+++ b/relnotes/ebtree-repo.feature.md
@@ -1,0 +1,3 @@
+### Add ebtree bintray repository
+
+Ebtree library is now released via its own Bintray repository.


### PR DESCRIPTION
Ebtree library is not release via its own Bintray repository.

This is based on the bionic support PR.