### PR TITLE
develdlang: Add back missing ebtree repo

### DIFF
--- a/docker/develdlang
+++ b/docker/develdlang
@@ -11,7 +11,8 @@ set -xeu
 dist="$(lsb_release -cs)"
 
 # Add extra dlang APT repositories from Sociomantic and dlang-community in Bintray
-apt_add_bintray_repos sociomantic-tsunami/dlang dlang-community/apt
+apt_add_bintray_repos sociomantic-tsunami/ebtree sociomantic-tsunami/dlang \
+		dlang-community/apt
 
 # Add extra DMD D-APT repo
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EBCF975E5BA24D5E


### PR DESCRIPTION
This repo was removed accidentally in
1c98f1f4b0f59e8fe98bbe82ba7f166e1e8d2325.