### PR TITLE
Add dumb-init binary to runtimebase image.

### DIFF
--- a/docker/runtimebase
+++ b/docker/runtimebase
@@ -21,3 +21,9 @@ apt -y full-upgrade
 
 # Remove common temporary files and packages
 cleanup
+
+# Add Yelp's dumb-init
+curl -sL "https://github.com/Yelp/dumb-init/releases/download/v${VERSION_DUMB_INIT}/dumb-init_${VERSION_DUMB_INIT}_amd64" \
+        -o /usr/local/bin/dumb-init
+echo "${DUMB_INIT_SHA256} /usr/local/bin/dumb-init" | sha256sum -c
+chmod +x /usr/local/bin/dumb-init

--- a/docker/util.sh
+++ b/docker/util.sh
@@ -78,7 +78,7 @@ apt_update_and_install_base_packages()
 	esac
 
 	# We install some basic packages first.
-	apt -y install apt-transport-https software-properties-common $extra_packages
+	apt -y install apt-transport-https software-properties-common curl $extra_packages
 }
 
 apt_install_bintray_key()

--- a/relnotes/init.migration.md
+++ b/relnotes/init.migration.md
@@ -1,0 +1,10 @@
+### Use init system as runtimebase ENTRYPOINT
+
+Now `runtimebase` image overrides `ENTRYPOINT` to use [dumb-init](https://github.com/Yelp/dumb-init)
+as an init system. In practice that means that all images that use `runtimebase`
+as a base in their `Dockefile` must specify command to start their application
+using `CMD` directive and must not change `ENTRYPOINT`.
+
+Benefit is that dumb-init will manage signal handling and zombie processes in
+a similar way to regular Linux init system, allowing most applications to work
+as-is inside the container.

--- a/runtimebase.Dockerfile
+++ b/runtimebase.Dockerfile
@@ -6,10 +6,17 @@ FROM ubuntu
 
 ARG VERSION_IMAGE
 
+# DUMB-INIT
+# SOURCE https://github.com/Yelp/dumb-init
+ARG VERSION_DUMB_INIT="1.2.2"
+ARG DUMB_INIT_SHA256="37f2c1f0372a45554f1b89924fbb134fc24c3756efaedf11e07f599494e0eff9"
+
 ENV DEBIAN_FRONTEND=noninteractive \
     # Environment variables for program and image versions
     # (scripts use them to know which version to install)
-    VERSION_IMAGE=$VERSION_IMAGE
+    VERSION_IMAGE=$VERSION_IMAGE \
+    VERSION_DUMB_INIT=$VERSION_DUMB_INIT \
+    DUMB_INIT_SHA256=$DUMB_INIT_SHA256
 
 LABEL \
     maintainer="dunnhumby Germany GmbH <tsunami@sociomantic.com>" \
@@ -19,3 +26,5 @@ LABEL \
 
 COPY docker/ /docker-tmp
 RUN cd /docker-tmp && ./runtimebase && rm -fr /docker-tmp
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]


### PR DESCRIPTION
As we preparing containers to run in Kubernetes and want them to handle
signals better.

Refs #66