### PR TITLE
Use experimental keyserver hkps://keys.openpgp.org

### DIFF
--- a/docker/develbase
+++ b/docker/develbase
@@ -23,7 +23,7 @@ apt -y full-upgrade
 git config --system user.name "Cachalot Docker image"
 git config --system user.email "tsunami@sociomantic.com"
 
-# fpm installation is release-dependant
+# travis installation is release-dependant
 gem install $(gem_ver travis "$VERSION_TRAVIS")
 
 # fpm installation is release-dependant

--- a/docker/develdlang
+++ b/docker/develdlang
@@ -15,7 +15,7 @@ apt_add_bintray_repos sociomantic-tsunami/ebtree sociomantic-tsunami/dlang \
 		dlang-community/apt
 
 # Add extra DMD D-APT repo
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EBCF975E5BA24D5E
+apt-key adv --keyserver hkps://keys.openpgp.org --recv-keys EBCF975E5BA24D5E
 # Added manually until D-APT is fixed
 #wget http://downloads.sourceforge.net/project/d-apt/files/d-apt.list \
 #               -O /etc/apt/sources.list.d/d-apt.list

--- a/docker/util.sh
+++ b/docker/util.sh
@@ -70,7 +70,10 @@ apt_update_and_install_base_packages()
 	# Select extra packages depending on the distro version
 	case "$dist" in
 	bionic)
-		extra_packages="gpg-agent dirmngr"
+		extra_packages="gpg-agent"
+		;;
+	xenial)
+		extra_packages="gnupg-agent gnupg-curl"
 		;;
 	*)
 		extra_packages=
@@ -78,12 +81,13 @@ apt_update_and_install_base_packages()
 	esac
 
 	# We install some basic packages first.
-	apt -y install apt-transport-https software-properties-common curl $extra_packages
+	apt -y install apt-transport-https software-properties-common curl dirmngr \
+			$extra_packages
 }
 
 apt_install_bintray_key()
 {
-	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+	apt-key adv --keyserver hkps://keys.openpgp.org --recv-keys 379CE192D401AB61
 }
 
 apt_add_bintray_repos()


### PR DESCRIPTION
The SKS keyserver network is vulnerable to spam attacks, and these attacks started to happen. Downloading a spammed key will break GnuPG installation "in hard to debug ways". To mitigate this problem, switch to using a new experimental keyserver that is not part of the SKS network. This server has its own limitations, but it seems to be the way to go in the future.

For more information about the SKS network attack:
https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f

Fixes #72.