### PR TITLE
Debug images build

### DIFF
--- a/develbase.Dockerfile
+++ b/develbase.Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     VERSION_IMAGE=$VERSION_IMAGE \
     # fpm is a tool to easily build Debian packages
     # https://fpm.readthedocs.io/en/latest/
-    VERSION_FPM=1.10.x \
+    VERSION_FPM=1.11.x \
     # travis is a command-line inteface to the travis CI service
     # https://github.com/travis-ci/travis.rb#the-travis-client-
     VERSION_TRAVIS=1.8.x \


### PR DESCRIPTION
This is a work-in-progress to fix #76

- Reducing the number of simultaneous jobs might help
debugging the images build which fails sometimes

- There is a known issue that unables to install
fpm due to the version of childprocess gem.
The fix for the issue was included in fpm from v1.11.0.
For more details see https://github.com/jordansissel/fpm/issues/1592

