### PR TITLE
Add release notes file

### DIFF
--- a/relnotes/versions.migrated.md
+++ b/relnotes/versions.migrated.md
@@ -1,0 +1,5 @@
+### Tools and libraries versions bumped
+
+* `base` image
+
+  * `fpm` 1.10.x -> 1.11.x


### PR DESCRIPTION
The release notes file was missing and it is
required in order to use the 'neptune-release' tool.