### PR TITLE
Build Ubuntu bionic image for runtimebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
         - TAG="$TRAVIS_TAG"
     matrix:
         - DIST=xenial
-        - DIST=bionic IMAGES=develbase
+        - DIST=bionic IMAGES="develbase runtimebase"
 
 script:
     - make -rj2 pre-test

--- a/relnotes/add-runtimebase-bionic-support.feature.md
+++ b/relnotes/add-runtimebase-bionic-support.feature.md
@@ -1,0 +1,6 @@
+### Add Ubuntu bionic support for runtimebase image
+
+* `runtimebase` image
+
+Builds the Ubuntu bionic image for runtimebase now that all the debian packages
+dependencies are available for that distribution.


### PR DESCRIPTION
Builds the Ubuntu bionic image for runtimebase now that all the debian packages dependencies are available for that distribution.