### PR TITLE
Add epoch for libebtree version

### DIFF
--- a/develdlang.Dockerfile
+++ b/develdlang.Dockerfile
@@ -10,7 +10,7 @@ ENV \
     # Environment variables for program and image versions
     # (scripts use them to know which version to install)
     VERSION_IMAGE=$VERSION_IMAGE \
-    VERSION_EBTREE=6.0.socio* \
+    VERSION_EBTREE=1:6.0.socio* \
     VERSION_DMD1=1.082.* \
     VERSION_TANGORT=1.9.* \
     VERSION_DMD=2.080.* \

--- a/relnotes/add-epoch-libebtree-version.feature.md
+++ b/relnotes/add-epoch-libebtree-version.feature.md
@@ -1,0 +1,9 @@
+###  Add epoch for libebtree version
+
+* `develdlang` image
+
+The new packages for libebtree support the new dpkg's epoch, so that the
+ordering can be preserved for the new versions using `.sX` scheme.
+This change makes possible to use the latest libebtree package (pre-release or
+release) available in the repository for Ubuntu xenial and bionic distributions
+when building the image.


### PR DESCRIPTION
The new packages for libebtree support the new dpkg's epoch, so that the
ordering can be preserved for the new versions using `.sX` scheme.
This change makes possible to use the latest libebtree package (pre-release
or release) available in the repository for Ubuntu xenial and bionic
distributions when building the image.