### PR TITLE
Fix example in the documentation

### DIFF
--- a/build-img
+++ b/build-img
@@ -28,8 +28,8 @@ Options:
 
 Examples:
 
-# builds sociomantictsunami/develbase:v2-xenial image based on develbase.Dockerfile
-$0 sociomantictsunami/develbase:v2-xenial
+# builds sociomantictsunami/develbase:xenial-v7 image based on develbase.Dockerfile
+$0 sociomantictsunami/develbase:xenial-v7
 HELP
 }
 

--- a/relnotes/fix-example-documentation.bug.md
+++ b/relnotes/fix-example-documentation.bug.md
@@ -1,0 +1,6 @@
+### Fix example in the documentation
+
+* `build-img` script
+
+The example in the documentation of the script now matches the description
+in the help message to build an image.


### PR DESCRIPTION
The example in the documentation of the script now matches the description
in the help message to build an image.