### PR TITLE
develdlang: Build Ubuntu bionic image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
         - TAG="$TRAVIS_TAG"
     matrix:
         - DIST=xenial
-        - DIST=bionic IMAGES="develbase runtimebase"
+        - DIST=bionic
 
 script:
     - make -rj2 pre-test

--- a/develdlang.Dockerfile
+++ b/develdlang.Dockerfile
@@ -11,11 +11,8 @@ ENV \
     # (scripts use them to know which version to install)
     VERSION_IMAGE=$VERSION_IMAGE \
     VERSION_EBTREE=1:6.0.socio* \
-    VERSION_DMD1=1.082.* \
-    VERSION_TANGORT=1.9.* \
     VERSION_DMD=2.080.* \
     VERSION_DMD_TRANSITIONAL=2.078.* \
-    VERSION_D1TO2FIX=0.10.* \
     VERSION_HMOD=0.3.*
 
 LABEL \
@@ -24,11 +21,8 @@ LABEL \
     # Labels for programs and image versions
     com.sociomantic.version.image=$VERSION_IMAGE \
     com.sociomantic.version.ebtree=$VERSION_EBTREE \
-    com.sociomantic.version.dmd1=$VERSION_DMD1 \
-    com.sociomantic.version.tangort=$VERSION_TANGORT \
     com.sociomantic.version.dmd=$VERSION_DMD \
     com.sociomantic.version.dmd-transitional=$VERSION_DMD_TRANSITIONAL \
-    com.sociomantic.version.d1to2fix=$VERSION_D1TO2FIX \
     com.sociomantic.version.hmod=$VERSION_HMOD
 
 COPY docker/ /docker-tmp

--- a/docker/develdlang
+++ b/docker/develdlang
@@ -37,10 +37,7 @@ apt_pin_install \
 	libebtree6="$VERSION_EBTREE" \
 		libebtree6-dbg="$VERSION_EBTREE" \
 		libebtree6-dev="$VERSION_EBTREE" \
-	dmd1="$VERSION_DMD1" \
-	libtangort-dmd-dev="$VERSION_TANGORT" \
 	dmd-transitional="$VERSION_DMD_TRANSITIONAL" \
-	d1to2fix="$VERSION_D1TO2FIX" \
 	$DMD_PKG \
 	hmod="$VERSION_HMOD"
 

--- a/relnotes/full-support-bionic.migration.md
+++ b/relnotes/full-support-bionic.migration.md
@@ -1,0 +1,14 @@
+### Support Ubuntu bionic for all images
+
+* `develdlang` image: Drop D1 support
+
+Ubuntu bionic requires builds to use position independent code
+(i.e. the `-fPIC` build flag). D1 does not support it and has been dropped.
+
+These debian packages will be no longer provided:
+- dmd1
+- libtangort-dmd-dev
+- d1to2fix
+
+D applications using the compiler dmd-transitional will need to add the `-fPIC`
+build flag, otherwise linking will fail.

--- a/test/develdlang-root
+++ b/test/develdlang-root
@@ -13,10 +13,7 @@ pkgs=$(cat <<EOT
 	libebtree6
 	libebtree6-dbg
 	libebtree6-dev
-	dmd1
-	libtangort-dmd-dev
 	dmd-transitional
-	d1to2fix
 	dmd-bin
 	libphobos2-dev
 EOT

--- a/test/develdlang-user
+++ b/test/develdlang-user
@@ -8,16 +8,10 @@ set -xeu
 # libebtree is present
 dpkg -L libebtree6-dev
 
-# Minimal dmd1 and rdmd test
-echo 'void main() {}' > /tmp/x.d
-dmd1 -run /tmp/x.d
-rdmd --compiler=dmd1 /tmp/x.d
-
-# Minimal d1to2fix test
-d1to2fix /tmp/x.d
-
 # Minimal dmd and dmd-transitional test with rdmd and the converted code
+echo 'void main() {}' > /tmp/x.d
+
 dmd -run /tmp/x.d
 rdmd --compiler=dmd /tmp/x.d
-dmd-transitional -run /tmp/x.d
-rdmd --compiler=dmd-transitional /tmp/x.d
+dmd-transitional -fPIC -run /tmp/x.d
+rdmd --compiler=dmd-transitional -fPIC /tmp/x.d


### PR DESCRIPTION
Ubuntu bionic requires builds to use position independent code
(i.e. the -fPIC build flag). D1 does not support it and has been dropped.

These debian packages will be no longer provided:
- dmd1
- libtangort-dmd-dev
- d1to2fix

D applications using the compiler dmd-transitional will need to add the -fPIC
build flag, otherwise linking will fail.