### PR TITLE
Remove xenial support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ services:
 
 env:
     global:
-        - LATEST_DIST=xenial
+        - LATEST_DIST=bionic
         - BRANCH="$TRAVIS_BRANCH"
         - TAG="$TRAVIS_TAG"
     matrix:
-        - DIST=xenial
         - DIST=bionic
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # =============
 
 # Default distributions to build
-DIST ?= xenial bionic
+DIST ?= bionic
 
 # Default DockerHub organization to use to tag (/push) images
 DOCKER_ORG ?= sociomantictsunami

--- a/build-img
+++ b/build-img
@@ -28,8 +28,8 @@ Options:
 
 Examples:
 
-# builds sociomantictsunami/develbase:xenial-v7 image based on develbase.Dockerfile
-$0 sociomantictsunami/develbase:xenial-v7
+# builds sociomantictsunami/develbase:bionic-v8 image based on develbase.Dockerfile
+$0 sociomantictsunami/develbase:bionic-v8
 HELP
 }
 


### PR DESCRIPTION
Is very close to the end of life and it's lacking Ruby 2.4 needed for the travis gem, so the build currently fails anyway.

This is a breaking change, so it might need to go to v9.x.x, but if xenial is broken, then v8.x.x will be broken for all new releases anyway, so...